### PR TITLE
Fix user-assigned managed identity authentication failure in blob binding

### DIFF
--- a/azure-functions-nodejs-extensions-blob/package-lock.json
+++ b/azure-functions-nodejs-extensions-blob/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0-preview",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "^0.1.0-preview",
+                "@azure/functions-extensions-base": "^0.2.0-preview",
                 "@azure/identity": "^4.9.1",
                 "@azure/storage-blob": "^12.27.0"
             },
@@ -172,10 +172,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.1.0-preview",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.1.0-preview.tgz",
-            "integrity": "sha512-Bl94Xst8UpUoSMrJ70ZuFA9E+sIH5v1siKAAkgle7BETdWyn2Aq5USQ7np7LuJtVgUp3+6PeiP7/Fw8gPpzrZQ==",
-            "license": "MIT",
+            "version": "0.2.0-preview",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0-preview.tgz",
+            "integrity": "sha512-kwbtV16ahkM3w9Vzp6Aof8gy4TkmIgGxfbPGKBQ0pd804fsp+eeWxQlgbal5+4l4dzMLSkzXC7mkURM1cyihnA==",
             "engines": {
                 "node": ">=18.0"
             }

--- a/azure-functions-nodejs-extensions-blob/package.json
+++ b/azure-functions-nodejs-extensions-blob/package.json
@@ -76,6 +76,6 @@
     "dependencies": {
         "@azure/identity": "^4.9.1",
         "@azure/storage-blob": "^12.27.0",
-        "@azure/functions-extensions-base": "^0.1.0-preview"
+        "@azure/functions-extensions-base": "^0.2.0-preview"
     }
 }

--- a/azure-functions-nodejs-extensions-blob/src/storage-blob/cacheableStorageBlobClientFactory.ts
+++ b/azure-functions-nodejs-extensions-blob/src/storage-blob/cacheableStorageBlobClientFactory.ts
@@ -107,10 +107,6 @@ export class CacheableAzureStorageBlobClientFactory {
      * Creates the appropriate connection strategy based on the connection name and URL
      */
     static createConnectionStrategy(connectionName: string, connectionUrl: string): StorageBlobServiceClientStrategy {
-        // Check for system-assigned managed identity
-        if (isSystemBasedManagedIdentity(connectionName)) {
-            return new ManagedIdentitySystemStrategy(connectionUrl);
-        }
         // Check User-assigned managed identity
         if (isUserBasedManagedIdentity(connectionName)) {
             const clientId = process.env[`${connectionName}__clientId`];
@@ -119,7 +115,10 @@ export class CacheableAzureStorageBlobClientFactory {
             }
             return new ManagedIdentityUserStrategy(connectionUrl, clientId);
         }
-
+        // Check for system-assigned managed identity
+        if (isSystemBasedManagedIdentity(connectionName)) {
+            return new ManagedIdentitySystemStrategy(connectionUrl);
+        }
         // Default to connection string
         return new ConnectionStringStrategy(connectionUrl);
     }

--- a/azure-functions-nodejs-extensions-blob/src/storage-blob/registerStorageBlobClientFactory.ts
+++ b/azure-functions-nodejs-extensions-blob/src/storage-blob/registerStorageBlobClientFactory.ts
@@ -12,9 +12,7 @@ export function registerStorageBlobClientFactory(): void {
             ResourceFactoryResolver.getInstance().registerResourceFactory(
                 AZURE_STORAGE_BLOBS,
                 (modelBindingData: ModelBindingData | ModelBindingData[]) => {
-                    console.log('here4 Registering client creation code from blob', modelBindingData);
                     if (Array.isArray(modelBindingData)) {
-                        // If it's an array, use the first element
                         throw new Error(`Batch request is not supported for blob`);
                     } else {
                         return CacheableAzureStorageBlobClientFactory.buildClientFromModelBindingData(modelBindingData);

--- a/azure-functions-nodejs-extensions-blob/src/storage-blob/registerStorageBlobClientFactory.ts
+++ b/azure-functions-nodejs-extensions-blob/src/storage-blob/registerStorageBlobClientFactory.ts
@@ -11,8 +11,14 @@ export function registerStorageBlobClientFactory(): void {
         if (!ResourceFactoryResolver.getInstance().hasResourceFactory(AZURE_STORAGE_BLOBS)) {
             ResourceFactoryResolver.getInstance().registerResourceFactory(
                 AZURE_STORAGE_BLOBS,
-                (modelBindingData: ModelBindingData) => {
-                    return CacheableAzureStorageBlobClientFactory.buildClientFromModelBindingData(modelBindingData);
+                (modelBindingData: ModelBindingData | ModelBindingData[]) => {
+                    console.log('here4 Registering client creation code from blob', modelBindingData);
+                    if (Array.isArray(modelBindingData)) {
+                        // If it's an array, use the first element
+                        throw new Error(`Batch request is not supported for blob`);
+                    } else {
+                        return CacheableAzureStorageBlobClientFactory.buildClientFromModelBindingData(modelBindingData);
+                    }
                 }
             );
         }


### PR DESCRIPTION
Description:

This PR fixes an issue where blob processing in Azure Functions using DefaultAzureCredential fails due to incorrect handling of user-assigned managed identities.

During blob processing for the function app failed to authenticate with the storage account due to an AggregateAuthenticationError. The ManagedIdentityCredential was defaulting to SystemAssignedManagedIdentity, even though a UserAssignedManagedIdentity was configured on the app and had proper RBAC access to the blob storage.

The root cause was identified in the blob client factory logic:

Fix:
Updated the logic to first attempt authentication using UserAssignedManagedIdentity (when available) before falling back to SystemAssigned.

Successfully tested with a Function App configured with a UAMI having correct Storage Blob Data Contributor role.