### PR TITLE
Fix gRPC serialization error for deadletterReason and deadletterErrorDescription

### DIFF
--- a/azure-functions-nodejs-extensions-servicebus/src/servicebus/ServiceBusMessageActions.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/servicebus/ServiceBusMessageActions.ts
@@ -135,8 +135,10 @@ export class ServiceBusMessageActions implements IServiceBusMessageActions {
             const request: DeadletterRequest = {
                 locktoken,
                 propertiesToModify: encodedProperties,
-                deadletterReason,
-                deadletterErrorDescription,
+                deadletterReason: deadletterReason ? { value: deadletterReason } : undefined,
+                deadletterErrorDescription: deadletterErrorDescription
+                    ? { value: deadletterErrorDescription }
+                    : undefined,
             };
 
             this.client.deadletter(request, (error: grpc.ServiceError | null) => {

--- a/azure-functions-nodejs-extensions-servicebus/test/servicebus/ServiceBusMessageActions.test.ts
+++ b/azure-functions-nodejs-extensions-servicebus/test/servicebus/ServiceBusMessageActions.test.ts
@@ -332,8 +332,8 @@ describe('ServiceBusMessageActions', () => {
                 sinon.match({
                     locktoken: message.lockToken,
                     propertiesToModify: sinon.match.instanceOf(Uint8Array),
-                    deadletterReason: reason,
-                    deadletterErrorDescription: errorDescription,
+                    deadletterReason: { value: reason },
+                    deadletterErrorDescription: { value: errorDescription },
                 }),
                 sinon.match.func
             );

--- a/azure-functions-nodejs-extensions-servicebus/types/settlement-types.d.ts
+++ b/azure-functions-nodejs-extensions-servicebus/types/settlement-types.d.ts
@@ -16,8 +16,8 @@ export interface AbandonRequest {
 export interface DeadletterRequest {
     locktoken: string;
     propertiesToModify: Uint8Array;
-    deadletterReason?: string;
-    deadletterErrorDescription?: string;
+    deadletterReason?: { value: string };
+    deadletterErrorDescription?: { value: string };
 }
 
 export interface DeferRequest {


### PR DESCRIPTION
## Summary

Fixes https://github.com/Azure/azure-functions-nodejs-extensions/issues/28

This PR fixes the gRPC serialization error that occurs when providing a string value for deadletterReason or deadletterErrorDescription to actions.deadletter().

## Problem

The protobuf definition for DeadletterRequest uses google.protobuf.StringValue for the deadletterReason and deadletterErrorDescription fields:

### protobuf

```
message DeadletterRequest {
  string locktoken = 1;
  bytes propertiesToModify = 2;
  google.protobuf.StringValue deadletterReason = 3;
  google.protobuf.StringValue deadletterErrorDescription = 4;
}
```

`StringValue` is a wrapper type that expects an object format { value: string }, not a plain string. Passing a plain string caused the error:

```
13 INTERNAL: Request message serialization failure: .DeadletterRequest.deadletterReason: object expected
```

## Solution

- Updated the DeadletterRequest interface in settlement-types.d.ts to use { value: string } type
- Modified ServiceBusMessageActions.ts to wrap string values in StringValue format when constructing the gRPC request
- Updated test expectations to match the new format

## Notes

- The public API (IServiceBusMessageActions.deadletter) remains unchanged
- Users still pass plain strings as parameters, which are converted internally to the correct format
- All existing tests pass