### PR TITLE
fix: Return raw Buffer from Service Bus message body for user-controlled parsing

### DIFF
--- a/azure-functions-nodejs-extensions-servicebus/package-lock.json
+++ b/azure-functions-nodejs-extensions-servicebus/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.3.6-preview",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions-extensions-servicebus",
-            "version": "0.3.6-preview",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/core-amqp": "^4.3.6",

--- a/azure-functions-nodejs-extensions-servicebus/package.json
+++ b/azure-functions-nodejs-extensions-servicebus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.3.6-preview",
+    "version": "0.4.0",
     "sideEffects": true,
     "description": "Node.js Azure ServiceBus extension implementations for Azure Functions",
     "keywords": [

--- a/azure-functions-nodejs-extensions-servicebus/src/constants.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.3.6-preview';
+export const version = '0.4.0';


### PR DESCRIPTION
## Summary

This PR changes the `decodeAmqpBody` method to return raw Buffer data instead of automatically parsing message content based on `contentType`.

## Problem

As reported in #27, users cannot access raw binary data when using the SDK binding `sdkBinding: true` for Service Bus triggers. The previous implementation automatically parsed JSON content:

- Messages with `contentType: 'application/json'` were parsed using `JSON.parse()`
- This prevented users from using custom JSON revivers
- Users could not control how special values (like large numbers) were handled
- The `dataType: 'binary'` option was ignored for SDK bindings

## Solution

**Return raw Buffer for all binary messages, regardless of contentType.**

This approach:
1. **Aligns with Python Extension behavior** - The Python Azure Functions Extension returns raw bytes without automatic parsing
2. **Gives users full control** - Users can parse the data however they need
3. **Enables custom JSON revivers** - Users can use `JSON.parse(buffer.toString(), reviver)`
4. **Preserves data integrity** - No automatic type coercion or parsing errors

## Breaking Change

This is a **breaking change** for users who relied on automatic JSON parsing.

### Before (v0.3.x)
Typescript
```
// message.body was already a parsed JavaScript object
const data = message.body; // { name: 'test', value: 42 }
```

### After (this PR)
Typescript

```
// message.body is now a Buffer
const data = JSON.parse(message.body.toString('utf8'));

// Or with a custom reviver for special handling
const data = JSON.parse(message.body.toString('utf8'), (key, value) => {
  // Custom parsing logic here
  return value;
});
```

## Why This Design Decision?

1. **Consistency with Python**: The Python Extension does not auto-parse, so Node.js should behave the same way
2. **User Control**: Auto-parsing removes user control over an important step in data processing
3. **Predictability**: The body type is now always Buffer for binary messages, not dependent on contentType
4. **Issue #27**: This directly addresses the reported issue where users needed raw data access

## Testing

- Updated existing tests to expect Buffer return type
- Added new tests for:
  - Raw Buffer returned for all content types
  - User-controlled JSON parsing with custom revivers
  - Binary data integrity preservation

All 209 tests pass.

## Checklist

- [x] Code changes implemented
- [x] Tests updated and passing
- [x] Breaking change documented
- [x] Rationale explained

Fixes #27