### PR TITLE
Add text() and json<T>() convenience methods to ServiceBusMessage

### DIFF
--- a/azure-functions-nodejs-extensions-servicebus/src/index.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/index.ts
@@ -6,7 +6,7 @@ import { registerServiceBusMessageFactory } from './servicebus/registerServiceBu
 registerServiceBusMessageFactory();
 
 // Export types for customer consumption
-export type { ServiceBusMessageContext } from '../types';
+export type { ServiceBusMessage, ServiceBusMessageContext } from '../types';
 export type { IServiceBusMessageActions } from '../types/settlement-types';
 
 // Export AMQP property encoding utilities

--- a/azure-functions-nodejs-extensions-servicebus/types/index.d.ts
+++ b/azure-functions-nodejs-extensions-servicebus/types/index.d.ts
@@ -4,8 +4,50 @@
 import { ServiceBusReceivedMessage } from '@azure/service-bus';
 import { ServiceBusMessageActions } from '../src/servicebus/ServiceBusMessageActions';
 
+/**
+ * Extends ServiceBusReceivedMessage with convenience methods for body parsing.
+ *
+ * With v0.4.0, `message.body` returns a raw Buffer. These methods provide
+ * a simple, one-line experience for common parsing operations, consistent
+ * with the Azure Functions HTTP model pattern (`request.text()`, `request.json()`).
+ *
+ * Unlike the HTTP model methods which return Promises (because the body is a stream),
+ * these methods are synchronous because the message body is already fully materialized.
+ */
+export interface ServiceBusMessage extends ServiceBusReceivedMessage {
+    /**
+     * Returns the message body as a UTF-8 string.
+     *
+     * - If body is a Buffer, decodes as UTF-8
+     * - If body is already a string, returns as-is
+     * - For other types, returns JSON.stringify result
+     *
+     * @example
+     * ```typescript
+     * const text = message.text();
+     * ```
+     */
+    text(): string;
+
+    /**
+     * Parses the message body as JSON and returns a typed result.
+     *
+     * Equivalent to `JSON.parse(message.text())`.
+     *
+     * @typeParam T - The expected type of the parsed JSON
+     * @throws {SyntaxError} If the body is not valid JSON
+     *
+     * @example
+     * ```typescript
+     * interface MyEvent { id: string; data: number; }
+     * const event = message.json<MyEvent>();
+     * ```
+     */
+    json<T = unknown>(): T;
+}
+
 export interface ServiceBusMessageContext {
-    messages: ServiceBusReceivedMessage[];
+    messages: ServiceBusMessage[];
     actions: ServiceBusMessageActions;
 }
 


### PR DESCRIPTION
## Summary

Add `message.text()` and `message.json<T>()` convenience methods to Service Bus messages, addressing the v0.4.0 boilerplate issue (#50).

With v0.4.0, `message.body` returns a raw `Buffer` instead of an auto-parsed object. This requires 3 lines of boilerplate for the most common use case (JSON text messages):

~~~typescript
// Before (v0.4.0 - 3 lines)
const bodyBuffer = message.body as Buffer;
const bodyText = bodyBuffer.toString('utf8');
const bodyData = JSON.parse(bodyText);

// After (this PR - 1 line)
const data = message.json<MyType>();
const text = message.text();
~~~

## Design

- **New `ServiceBusMessage` interface** extending `ServiceBusReceivedMessage` with `text()` and `json<T>()` methods
- **Synchronous methods** (unlike HTTP model's async `request.text()`/`request.json()`) because the message body is already fully materialized as a Buffer, not a stream
- **Generic `json<T>()`** for TypeScript DX, matching the interim helper pattern
- Methods injected directly onto the plain object in `azureServiceBusMessageFactory.ts`

## Breaking Change Analysis

| Change | Impact | Assessment |
|--------|--------|------------|
| `ServiceBusMessageContext.messages` type changes from `ServiceBusReceivedMessage[]` to `ServiceBusMessage[]` | `ServiceBusMessage extends ServiceBusReceivedMessage`, so existing code treating messages as `ServiceBusReceivedMessage` will continue to work | **Not breaking** |
| `text()` and `json()` methods added to message | New members only, no existing properties affected | **Not breaking** |
| `ServiceBusMessage` type exported from package | New export, does not affect existing exports | **Not breaking** |

**Conclusion: No breaking changes.** The `ServiceBusMessage` interface is a strict supertype of `ServiceBusReceivedMessage`. All existing consumer code remains compatible.

## Changes

- **types/index.d.ts** - Add `ServiceBusMessage` interface with `text(): string` and `json<T>(): T`
- **azureServiceBusMessageFactory.ts** - Inject `text()` and `json<T>()` into message objects; return type changed to `ServiceBusMessage`
- **src/index.ts** - Export `ServiceBusMessage` type
- **azureServiceBusMessageFactory.test.ts** - 16 new unit tests (text: 8 cases, json: 7 cases, integration: 1 case)

## Test Results

- 225 tests passing (209 existing + 16 new)
- webpack build successful

## Related

- Closes #50
- Related to #27 (v0.4.0 breaking change)
