### PR TITLE
fix(base): use globalThis + Symbol.for() for process-wide singleton (Issue #26)

### DIFF
--- a/azure-functions-nodejs-extensions-base/package.json
+++ b/azure-functions-nodejs-extensions-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-base",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "sideEffects": true,
     "description": "Node.js Azure Storage Client extension implementations for Azure Functions",
     "keywords": [

--- a/azure-functions-nodejs-extensions-base/src/constants.ts
+++ b/azure-functions-nodejs-extensions-base/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.2.0';
+export const version = '0.3.0';


### PR DESCRIPTION
## Summary

Fixes #26. Resolves the singleton conflict that occurs when bundlers (esbuild, webpack) inline `@azure/functions-extensions-base`, creating duplicate `ResourceFactoryResolver` instances.

## Problem

When users bundle their Azure Functions app with esbuild/webpack and do NOT mark `@azure/functions-extensions-base` as external, the bundler inlines the package. Meanwhile, `@azure/functions` (which must remain external for OpenTelemetry) also imports the base package at runtime. This creates two separate copies of `ResourceFactoryResolver`:

1. One inlined by the bundler (servicebus extension registers factory here)
2. One loaded at runtime by `@azure/functions` (library looks for factory here)

The factory registered in copy #1 is invisible to copy #2, causing "No resource factory found" errors.

## Solution

Replace the module-scoped singleton pattern with a process-wide singleton using `globalThis` and `Symbol.for()`:

~~~typescript
const SINGLETON_KEY = Symbol.for('@azure/functions-extensions-base.ResourceFactoryResolver');

static getInstance(): ResourceFactoryResolver {
    const g = globalThis as Record<symbol, unknown>;
    if (!g[SINGLETON_KEY]) {
        g[SINGLETON_KEY] = new ResourceFactoryResolver();
    }
    return g[SINGLETON_KEY] as ResourceFactoryResolver;
}
~~~

`Symbol.for()` uses a global Symbol registry - the same string key always returns the same Symbol regardless of which module copy calls it. Combined with `globalThis`, this creates a truly process-wide singleton.

## Changes

| Package | File | Change |
|---------|------|--------|
| base | `resourceFactoryResolver.ts` | Replaced `private static instance` with `globalThis[Symbol.for()]` |
| base | `resourceFactoryResolver.test.ts` | Added 4 new globalThis singleton tests (14 total, all passing) |
| base | `constants.ts` + `package.json` | Version bump 0.2.0 -> 0.3.0 |
| servicebus | `samples/serviceBusEsbuildWorkaround/*` | Added sample for reproducing and verifying the fix |

## Breaking Changes

**None.** Public API signatures are unchanged:
- `getInstance()`
- `registerResourceFactory()`
- `createClient()`
- `hasResourceFactory()`

## Testing

### Unit Tests
14 tests passing (10 original + 4 new globalThis tests)

### E2E Test
Tested with the `serviceBusEsbuildWorkaround` sample:

1. `build:broken` (bundles base into esbuild without external) - **now works**
2. Sent message to Azure Service Bus queue
3. Function triggered and processed successfully:

~~~
[2026-02-17T19:21:30.525Z] Successfully received Service Bus message via SDK binding!
[2026-02-17T19:21:30.670Z] Message completed successfully.
[2026-02-17T19:21:30.688Z] Executed 'Functions.serviceBusTrigger' (Succeeded, Duration=294ms)
~~~

## Workaround Guidance (until base 0.3.0 is published)

Users can still use the workaround documented in #26:
- **esbuild**: Add `@azure/functions-extensions-base` to `external` array
- **pnpm**: Add `publicHoistPattern: ["*@azure/functions-extensions*"]` to `.npmrc`
