### PR TITLE
fix(ci): add CFS bypass to public build pipeline

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -23,6 +23,13 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
+
+variables:
+  - template: /ci/variables/cfs.yml@eng
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es


### PR DESCRIPTION
## Summary

Fix CI pipeline failure caused by CFSClean network isolation policy blocking `registry.npmjs.org` during `npm ci`.

## Problem

The public build pipeline (`Azure-Functions-Nodejs-Extensions-Public`, pipeline ID 1689) fails on all 3 build jobs (base, blob, servicebus) with:

~~~
npm error Exit handler never called!
~~~

**Root cause**: The 1ES Network Isolation `CFSClean` policy blocks outbound connections to `registry.npmjs.org`. The `npm ci` step cannot download packages, and npm crashes when the network connection is forcibly terminated.

## Investigation

- Compared network isolation policies between the **Worker repo** (passing) and **Extensions repo** (failing):
  - Worker: `["Permissive", "CFSClean2"]` — no CFSClean, npm registry accessible
  - Extensions: `["CFSClean2", "Permissive", "CFSClean", "Permissive"]` — CFSClean blocks npm
- Found that `official-build.yml` already references the `engineering` repo's `cfs.yml` variable template which sets `DisableCFSDetector: true`
- `public-build.yml` was missing this reference

## Fix

Add the `engineering` repository resource and `cfs.yml` variable template to `public-build.yml`, matching the existing pattern in `official-build.yml`.

~~~yaml
resources:
  repositories:
    - repository: eng
      type: git
      name: engineering
      ref: refs/tags/release

variables:
  - template: /ci/variables/cfs.yml@eng
~~~

## Changes

- `eng/ci/public-build.yml` — Add `engineering` repo resource + CFS bypass variables (7 lines added)
