### PR TITLE
fix: bump fast-xml-parser to 5.4.1 in serviceBusBinaryDataAccess sample

### DIFF
--- a/azure-functions-nodejs-extensions-servicebus/samples/serviceBusBinaryDataAccess/package-lock.json
+++ b/azure-functions-nodejs-extensions-servicebus/samples/serviceBusBinaryDataAccess/package-lock.json
@@ -963,10 +963,22 @@
                 "node": ">=0.8.x"
             }
         },
+        "node_modules/fast-xml-builder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+            "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/fast-xml-parser": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
-            "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+            "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
             "funding": [
                 {
                     "type": "github",
@@ -975,6 +987,7 @@
             ],
             "license": "MIT",
             "dependencies": {
+                "fast-xml-builder": "^1.0.0",
                 "strnum": "^2.1.2"
             },
             "bin": {
@@ -1520,13 +1533,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
## Fix fast-xml-parser vulnerability in serviceBusBinaryDataAccess sample

### Summary

Bumps `fast-xml-parser` from `5.3.5` to `5.4.1` in the `serviceBusBinaryDataAccess` sample's `package-lock.json` via `npm audit fix`.

### CVEs Addressed

| CVE | Severity | Description | Fixed In |
|-----|----------|-------------|----------|
| [CVE-2026-26278](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj) | **High** (7.5/10) | DoS via entity expansion in DOCTYPE (no expansion limit) | 5.3.6 |
| [CVE-2026-27942](https://github.com/advisories/GHSA-fj3w-jwp8-x2g3) | Low (2.7/10) | Stack overflow in XMLBuilder with `preserveOrder: true` | 5.3.8 |

### Context

- PR #68 and PR #60 already patched the main `servicebus` and `blob` `package-lock.json` files
- This PR fixes the remaining tracked sample (`serviceBusBinaryDataAccess`) whose lock file still resolved to `5.3.5`
- The `serviceBusEsbuildWorkaround` sample has `package-lock.json` in its `.gitignore` by design (users get latest on `npm install`)

### Testing

All 4 ServiceBus samples were E2E tested locally with `func start` after the fix:

| Sample | Queue | Result |
|--------|-------|--------|
| serviceBusSampleWithComplete | testqueue | PASS |
| serviceBusBinaryDataAccess | testqueue | PASS |
| serviceBusEsbuildWorkaround | myqueue | PASS |
| serviceBusTriggerExponentialBackOff | testqueue | PASS |

**Environment:** Node.js v22.17.0, Azure Functions Core Tools 4.7.0, ServiceBus `sb-fpnwvn4q6m7tc.servicebus.windows.net`
