### PR TITLE
ESM Support

### DIFF
--- a/azure-functions-nodejs-extensions-base/package-lock.json
+++ b/azure-functions-nodejs-extensions-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions-extensions-base",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions-extensions-base",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/chai": "^4.2.22",

--- a/azure-functions-nodejs-extensions-base/package.json
+++ b/azure-functions-nodejs-extensions-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-base",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "sideEffects": true,
     "description": "Node.js Azure Storage Client extension implementations for Azure Functions",
     "keywords": [
@@ -21,7 +21,20 @@
         "url": "https://github.com/Azure/azure-functions-nodejs-extensions/issues"
     },
     "main": "./dist/azure-functions-extensions-base.js",
+    "module": "./dist/azure-functions-extensions-base.mjs",
     "types": "types/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-base.mjs"
+            },
+            "require": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-base.js"
+            }
+        }
+    },
     "files": [
         "dist/",
         "src/",

--- a/azure-functions-nodejs-extensions-base/src/constants.ts
+++ b/azure-functions-nodejs-extensions-base/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.2.0';
+export const version = '0.3.0';

--- a/azure-functions-nodejs-extensions-base/webpack.config.js
+++ b/azure-functions-nodejs-extensions-base/webpack.config.js
@@ -3,7 +3,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 module.exports = (_env, argv) => {
     const isDevMode = argv.mode === 'development';
-    return {
+    const commonConfig = {
         entry: './src/index.ts',
         target: 'node',
         node: {
@@ -27,11 +27,6 @@ module.exports = (_env, argv) => {
         resolve: {
             extensions: ['.ts', '.tsx', '.js'],
         },
-        output: {
-            path: `${__dirname}/dist/`,
-            filename: isDevMode ? 'azure-functions-extensions-base.js' : 'azure-functions-extensions-base.min.js',
-            libraryTarget: 'commonjs2',
-        },
         plugins: [
             new ForkTsCheckerWebpackPlugin({}),
             new ESLintPlugin({
@@ -40,4 +35,25 @@ module.exports = (_env, argv) => {
             }),
         ],
     };
+
+    const cjsConfig = {
+        ...commonConfig,
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode ? 'azure-functions-extensions-base.js' : 'azure-functions-extensions-base.min.js',
+            libraryTarget: 'commonjs2',
+        },
+    };
+
+    const esmConfig = {
+        ...commonConfig,
+        experiments: { outputModule: true },
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode ? 'azure-functions-extensions-base.mjs' : 'azure-functions-extensions-base.min.mjs',
+            library: { type: 'module' },
+        },
+    };
+
+    return [cjsConfig, esmConfig];
 };

--- a/azure-functions-nodejs-extensions-blob/package-lock.json
+++ b/azure-functions-nodejs-extensions-blob/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions-extensions-blob",
-    "version": "0.2.0-preview",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions-extensions-blob",
-            "version": "0.2.0-preview",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions-extensions-base": "^0.2.0",

--- a/azure-functions-nodejs-extensions-blob/package.json
+++ b/azure-functions-nodejs-extensions-blob/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-blob",
-    "version": "0.2.0-preview",
+    "version": "0.3.0",
     "sideEffects": true,
     "description": "Node.js Azure Storage Client extension implementations for Azure Functions",
     "keywords": [
@@ -21,7 +21,20 @@
         "url": "https://github.com/Azure/azure-functions-nodejs-extensions/issues"
     },
     "main": "./dist/azure-functions-extensions-blob.js",
+    "module": "./dist/azure-functions-extensions-blob.mjs",
     "types": "types/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-blob.mjs"
+            },
+            "require": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-blob.js"
+            }
+        }
+    },
     "files": [
         "dist/",
         "src/",

--- a/azure-functions-nodejs-extensions-blob/src/constants.ts
+++ b/azure-functions-nodejs-extensions-blob/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.2.0-preview';
+export const version = '0.3.0';

--- a/azure-functions-nodejs-extensions-blob/webpack.config.js
+++ b/azure-functions-nodejs-extensions-blob/webpack.config.js
@@ -3,7 +3,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 module.exports = (_env, argv) => {
     const isDevMode = argv.mode === 'development';
-    return {
+    const commonConfig = {
         entry: './src/index.ts',
         target: 'node',
         node: {
@@ -27,11 +27,6 @@ module.exports = (_env, argv) => {
         resolve: {
             extensions: ['.ts', '.tsx', '.js'],
         },
-        output: {
-            path: `${__dirname}/dist/`,
-            filename: isDevMode ? 'azure-functions-extensions-blob.js' : 'azure-functions-extensions-blob.min.js',
-            libraryTarget: 'commonjs2',
-        },
         plugins: [
             new ForkTsCheckerWebpackPlugin({}),
             new ESLintPlugin({
@@ -40,4 +35,25 @@ module.exports = (_env, argv) => {
             }),
         ],
     };
+
+    const cjsConfig = {
+        ...commonConfig,
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode ? 'azure-functions-extensions-blob.js' : 'azure-functions-extensions-blob.min.js',
+            libraryTarget: 'commonjs2',
+        },
+    };
+
+    const esmConfig = {
+        ...commonConfig,
+        experiments: { outputModule: true },
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode ? 'azure-functions-extensions-blob.mjs' : 'azure-functions-extensions-blob.min.mjs',
+            library: { type: 'module' },
+        },
+    };
+
+    return [cjsConfig, esmConfig];
 };

--- a/azure-functions-nodejs-extensions-servicebus/package-lock.json
+++ b/azure-functions-nodejs-extensions-servicebus/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions-extensions-servicebus",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/core-amqp": "^4.3.6",

--- a/azure-functions-nodejs-extensions-servicebus/package.json
+++ b/azure-functions-nodejs-extensions-servicebus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "sideEffects": true,
     "description": "Node.js Azure ServiceBus extension implementations for Azure Functions",
     "keywords": [
@@ -20,12 +20,18 @@
         "url": "https://github.com/Azure/azure-functions-nodejs-extensions/issues"
     },
     "main": "./dist/azure-functions-extensions-servicebus.js",
+    "module": "./dist/azure-functions-extensions-servicebus.mjs",
     "types": "types/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/azure-functions-extensions-servicebus.js",
-            "require": "./dist/azure-functions-extensions-servicebus.js",
-            "types": "./types/index.d.ts"
+            "import": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-servicebus.mjs"
+            },
+            "require": {
+                "types": "./types/index.d.ts",
+                "default": "./dist/azure-functions-extensions-servicebus.js"
+            }
         }
     },
     "files": [

--- a/azure-functions-nodejs-extensions-servicebus/samples/serviceBusSampleWithComplete/src/functions/serviceBusTopicTrigger.ts
+++ b/azure-functions-nodejs-extensions-servicebus/samples/serviceBusSampleWithComplete/src/functions/serviceBusTopicTrigger.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import '@azure/functions-extensions-servicebus'; // Ensure the Service Bus extension is imported
-import { app, InvocationContext } from '@azure/functions';
-import { ServiceBusMessageContext, messageBodyAsJson } from '@azure/functions-extensions-servicebus';
+import { app, type InvocationContext } from '@azure/functions';
+import { type ServiceBusMessageContext, messageBodyAsJson } from '@azure/functions-extensions-servicebus';
 
 // This sample uses sdkBinding = true with manual message completion.
 // With v0.4.0, message.body is returned as a raw Buffer instead of auto-parsed object.

--- a/azure-functions-nodejs-extensions-servicebus/samples/serviceBusSampleWithComplete/tsconfig.json
+++ b/azure-functions-nodejs-extensions-servicebus/samples/serviceBusSampleWithComplete/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "esModuleInterop": true,
+    "module": "nodenext",
+    "target": "es2022",
     "outDir": "dist",
     "rootDir": ".",
     "sourceMap": true,
-    "strict": false
+    "strict": false,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
   }
 }

--- a/azure-functions-nodejs-extensions-servicebus/src/constants.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.4.1';
+export const version = '0.5.0';

--- a/azure-functions-nodejs-extensions-servicebus/types/index.d.ts
+++ b/azure-functions-nodejs-extensions-servicebus/types/index.d.ts
@@ -2,15 +2,36 @@
 // Licensed under the MIT License.
 
 import { ServiceBusReceivedMessage } from '@azure/service-bus';
-import { ServiceBusMessageActions } from '../src/servicebus/ServiceBusMessageActions';
+import { IServiceBusMessageActions } from './settlement-types';
+
+export declare class ServiceBusMessageActions implements IServiceBusMessageActions {
+    private constructor();
+    static getInstance(): ServiceBusMessageActions;
+    complete(message: ServiceBusReceivedMessage): Promise<void>;
+    abandon(message: ServiceBusReceivedMessage, propertiesToModify?: Record<string, any>): Promise<void>;
+    deadletter(
+        message: ServiceBusReceivedMessage,
+        propertiesToModify?: Record<string, any>,
+        deadletterReason?: string,
+        deadletterErrorDescription?: string
+    ): Promise<void>;
+    defer(message: ServiceBusReceivedMessage, propertiesToModify?: Record<string, any>): Promise<void>;
+    renewMessageLock(message: ServiceBusReceivedMessage): Promise<void>;
+    setSessionState(sessionId: string, sessionState: Uint8Array): Promise<void>;
+    releaseSession(sessionId: string): Promise<void>;
+    renewSessionLock(sessionId: string): Promise<Date>;
+}
 
 export interface ServiceBusMessageContext {
     messages: ServiceBusReceivedMessage[];
     actions: ServiceBusMessageActions;
 }
 
-export { ServiceBusMessageActions } from '../src/servicebus/ServiceBusMessageActions';
 export type { IServiceBusMessageActions } from './settlement-types';
 
 // Body parsing helper utilities
-export { messageBodyAsText, messageBodyAsJson } from '../src/util/messageBodyParser';
+export declare function messageBodyAsText(message: { body: unknown }): string;
+export declare function messageBodyAsJson<T = unknown>(
+    message: { body: unknown },
+    reviver?: (key: string, value: unknown) => unknown
+): T;

--- a/azure-functions-nodejs-extensions-servicebus/webpack.config.js
+++ b/azure-functions-nodejs-extensions-servicebus/webpack.config.js
@@ -3,7 +3,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 module.exports = (_env, argv) => {
     const isDevMode = argv.mode === 'development';
-    return {
+    const commonConfig = {
         entry: './src/index.ts',
         target: 'node',
         node: {
@@ -28,13 +28,6 @@ module.exports = (_env, argv) => {
         resolve: {
             extensions: ['.ts', '.tsx', '.js'],
         },
-        output: {
-            path: `${__dirname}/dist/`,
-            filename: isDevMode
-                ? 'azure-functions-extensions-servicebus.js'
-                : 'azure-functions-extensions-servicebus.min.js',
-            libraryTarget: 'commonjs2',
-        },
         plugins: [
             new ForkTsCheckerWebpackPlugin({
                 typescript: {
@@ -48,4 +41,29 @@ module.exports = (_env, argv) => {
             }),
         ],
     };
+
+    const cjsConfig = {
+        ...commonConfig,
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode
+                ? 'azure-functions-extensions-servicebus.js'
+                : 'azure-functions-extensions-servicebus.min.js',
+            libraryTarget: 'commonjs2',
+        },
+    };
+
+    const esmConfig = {
+        ...commonConfig,
+        experiments: { outputModule: true },
+        output: {
+            path: `${__dirname}/dist/`,
+            filename: isDevMode
+                ? 'azure-functions-extensions-servicebus.mjs'
+                : 'azure-functions-extensions-servicebus.min.mjs',
+            library: { type: 'module' },
+        },
+    };
+
+    return [cjsConfig, esmConfig];
 };


### PR DESCRIPTION
## Add ESM module support for all extension packages

Solves https://github.com/Azure/azure-functions-nodejs-extensions/issues/61

### Summary

All three `@azure/functions-extensions-*` packages previously only shipped CommonJS bundles, which forced consumers using ESM (`"type": "module"` in package.json) to set `verbatimModuleSyntax: false` in their tsconfig.json. This PR adds proper dual CJS/ESM output so modern TypeScript projects can use these packages natively with `verbatimModuleSyntax: true`.

### Changes

#### Dual CJS/ESM builds (`base`, `blob`, `servicebus`)

- **webpack.config.js**: Refactored to produce two bundles per build — a CJS `.js` bundle (`libraryTarget: 'commonjs2'`) and an ESM `.mjs` bundle (`library: { type: 'module' }` with `experiments: { outputModule: true }`)
- **package.json**: Added `"module"` field and conditional `exports` map with separate `import`/`require` conditions, each with proper `types` resolution:
  ```json
  "exports": {
    ".": {
      "import":  { "types": "./types/index.d.ts", "default": "./dist/<name>.mjs" },
      "require": { "types": "./types/index.d.ts", "default": "./dist/<name>.js" }
    }
  }
  ```

#### Self-contained type declarations (`servicebus`)

- **types/index.d.ts**: Replaced `import ... from '../src/'` re-exports with inline `declare class` and `declare function` declarations. Previously, the type definitions pulled in `.ts` source files from `src/`, which caused `verbatimModuleSyntax` errors in consumer projects since those source files used CJS-style imports.

#### ESM-compatible sample (`serviceBusSampleWithComplete`)

- Added `"type": "module"` to package.json
- Updated tsconfig to `module: "nodenext"`, `target: "es2022"`, `verbatimModuleSyntax: true`
- Upgraded TypeScript from `^4.0.0` to `^5.0.0` (required for `verbatimModuleSyntax`)
- Updated imports to use `type` keyword for type-only imports (e.g., `type InvocationContext`, `type ServiceBusMessageContext`)

#### Version bumps

| Package | Before | After |
|---|---|---|
| `@azure/functions-extensions-base` | 0.2.0 | 0.3.0 |
| `@azure/functions-extensions-blob` | 0.2.0-preview | 0.3.0 |
| `@azure/functions-extensions-servicebus` | 0.4.1 | 0.5.0 |

### Validation

- `npm install` + `npm run build` passes for all three packages (both CJS and ESM bundles produced)
- `npm test` passes for all three packages (base: 10, servicebus: 231, blob: 61)
- `serviceBusSampleWithComplete` builds successfully with `verbatimModuleSyntax: true` and outputs proper ESM `import` syntax