### PR TITLE
Fix ESM build configuration and remove minimist production dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,6 +398,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/
 # Logs
 logs
 *.log

--- a/azure-functions-nodejs-extensions-servicebus/package-lock.json
+++ b/azure-functions-nodejs-extensions-servicebus/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@azure/functions-extensions-servicebus",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/core-amqp": "^4.3.6",
@@ -14,15 +14,14 @@
                 "@azure/service-bus": "^7.9.5",
                 "@grpc/grpc-js": "^1.13.4",
                 "@grpc/proto-loader": "^0.7.15",
-                "@types/minimist": "^1.2.2",
-                "minimist": "^1.2.8",
                 "rhea": "^3.0.4"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
                 "@types/chai-as-promised": "^8.0.2",
+                "@types/minimist": "^1.2.2",
                 "@types/mocha": "^9.1.1",
-                "@types/node": "18.0.0",
+                "@types/node": "20.0.0",
                 "@types/sinon": "^17.0.4",
                 "@types/sinon-chai": "^4.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.12.1",
@@ -42,6 +41,7 @@
                 "globby": "^11.0.0",
                 "grpc_tools_node_protoc_ts": "^5.3.3",
                 "grpc-tools": "^1.13.0",
+                "minimist": "^1.2.8",
                 "mocha": "^11.1.0",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.5.1",
@@ -910,6 +910,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/mocha": {
@@ -920,9 +921,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-            "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.0.0.tgz",
+            "integrity": "sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==",
             "license": "MIT"
         },
         "node_modules/@types/parse-json": {
@@ -5117,6 +5118,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"

--- a/azure-functions-nodejs-extensions-servicebus/package.json
+++ b/azure-functions-nodejs-extensions-servicebus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/functions-extensions-servicebus",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "sideEffects": true,
     "description": "Node.js Azure ServiceBus extension implementations for Azure Functions",
     "keywords": [
@@ -58,8 +58,9 @@
     "devDependencies": {
         "@types/chai": "^4.2.22",
         "@types/chai-as-promised": "^8.0.2",
+        "@types/minimist": "^1.2.2",
         "@types/mocha": "^9.1.1",
-        "@types/node": "18.0.0",
+        "@types/node": "20.0.0",
         "@types/sinon": "^17.0.4",
         "@types/sinon-chai": "^4.0.0",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
@@ -79,6 +80,7 @@
         "globby": "^11.0.0",
         "grpc_tools_node_protoc_ts": "^5.3.3",
         "grpc-tools": "^1.13.0",
+        "minimist": "^1.2.8",
         "mocha": "^11.1.0",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.5.1",
@@ -99,8 +101,6 @@
         "@azure/service-bus": "^7.9.5",
         "@grpc/grpc-js": "^1.13.4",
         "@grpc/proto-loader": "^0.7.15",
-        "@types/minimist": "^1.2.2",
-        "minimist": "^1.2.8",
         "rhea": "^3.0.4"
     }
 }

--- a/azure-functions-nodejs-extensions-servicebus/src/constants.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-export const version = '0.5.0';
+export const version = '0.5.1';

--- a/azure-functions-nodejs-extensions-servicebus/src/util/grpcUriBuilder.ts
+++ b/azure-functions-nodejs-extensions-servicebus/src/util/grpcUriBuilder.ts
@@ -1,8 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import minimist from 'minimist';
-
+import { parseArgs } from 'node:util';
 /**
  *  GrpcUriBuilder is a utility class to build a gRPC URI from command line arguments.
  *  It expects two arguments: 'host' and 'port'.
@@ -15,14 +14,22 @@ export class GrpcUriBuilder {
      * @throws Error if 'host' or 'port' arguments are missing.
      */
     static build(): { uri: string; grpcMaxMessageLength: number } {
-        const parsedArgs = minimist(process.argv.slice(2));
+        const { values: parsedArgs } = parseArgs({
+            args: process.argv.slice(2),
+            options: {
+                host: { type: 'string' },
+                port: { type: 'string' },
+                'functions-grpc-max-message-length': { type: 'string' },
+            },
+            strict: false,
+        });
+
         const { host, port, 'functions-grpc-max-message-length': grpcMaxMessageLength } = parsedArgs;
 
         const missing: string[] = [];
         if (!host) missing.push("'host'");
         if (!port) missing.push("'port'");
         if (!grpcMaxMessageLength) missing.push("'functions-grpc-max-message-length'");
-
         if (missing.length) {
             throw new Error(`Missing required arguments: ${missing.join(', ')}`);
         }

--- a/azure-functions-nodejs-extensions-servicebus/test/util/grpcUriBuilder.test.ts
+++ b/azure-functions-nodejs-extensions-servicebus/test/util/grpcUriBuilder.test.ts
@@ -62,4 +62,108 @@ describe('GrpcUriBuilder', () => {
             "Missing required arguments: 'host', 'port', 'functions-grpc-max-message-length'"
         );
     });
+
+    it('should report only the missing arguments when some are present', () => {
+        process.argv = ['node', 'script', '--host=localhost'];
+
+        expect(() => GrpcUriBuilder.build()).to.throw(
+            "Missing required arguments: 'port', 'functions-grpc-max-message-length'"
+        );
+    });
+
+    it('should support space-separated argument form', () => {
+        process.argv = [
+            'node',
+            'script',
+            '--host',
+            'localhost',
+            '--port',
+            '5000',
+            '--functions-grpc-max-message-length',
+            '123456',
+        ];
+
+        const result = GrpcUriBuilder.build();
+        expect(result).to.deep.equal({
+            uri: 'localhost:5000',
+            grpcMaxMessageLength: 123456,
+        });
+    });
+
+    it('should ignore unknown flags passed by the host process', () => {
+        process.argv = [
+            'node',
+            'script',
+            '--host=localhost',
+            '--port=5000',
+            '--functions-grpc-max-message-length=123456',
+            '--some-unknown-flag=foo',
+            '--workerId=abc',
+        ];
+
+        const result = GrpcUriBuilder.build();
+        expect(result).to.deep.equal({
+            uri: 'localhost:5000',
+            grpcMaxMessageLength: 123456,
+        });
+    });
+
+    it('should tolerate positional arguments', () => {
+        process.argv = [
+            'node',
+            'script',
+            'positional1',
+            '--host=localhost',
+            '--port=5000',
+            'positional2',
+            '--functions-grpc-max-message-length=123456',
+        ];
+
+        const result = GrpcUriBuilder.build();
+        expect(result).to.deep.equal({
+            uri: 'localhost:5000',
+            grpcMaxMessageLength: 123456,
+        });
+    });
+
+    it('should use the last value when a flag is repeated', () => {
+        process.argv = [
+            'node',
+            'script',
+            '--host=first',
+            '--host=second',
+            '--port=5000',
+            '--functions-grpc-max-message-length=123456',
+        ];
+
+        const result = GrpcUriBuilder.build();
+        expect(result.uri).to.equal('second:5000');
+    });
+
+    // The following tests document edge cases that are likely bugs in the
+    // current implementation. Un-skip once the desired behavior is decided.
+
+    it.skip('should accept 0 as a valid grpc max message length', () => {
+        // Currently `if (!grpcMaxMessageLength)` rejects "0" because the
+        // empty/zero check runs against the raw string. Today this throws
+        // "Missing required arguments". Likely should be allowed (or rejected
+        // with a clearer "invalid value" error).
+        process.argv = ['node', 'script', '--host=localhost', '--port=5000', '--functions-grpc-max-message-length=0'];
+
+        const result = GrpcUriBuilder.build();
+        expect(result.grpcMaxMessageLength).to.equal(0);
+    });
+
+    it.skip('should reject a non-numeric grpc max message length', () => {
+        // Currently produces { grpcMaxMessageLength: NaN } silently.
+        process.argv = [
+            'node',
+            'script',
+            '--host=localhost',
+            '--port=5000',
+            '--functions-grpc-max-message-length=not-a-number',
+        ];
+
+        expect(() => GrpcUriBuilder.build()).to.throw(/functions-grpc-max-message-length/);
+    });
 });

--- a/azure-functions-nodejs-extensions-servicebus/test/util/messageBodyParser.test.ts
+++ b/azure-functions-nodejs-extensions-servicebus/test/util/messageBodyParser.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { expect } from 'chai';
-import { messageBodyAsText, messageBodyAsJson } from '../../src/util/messageBodyParser';
+import { messageBodyAsJson, messageBodyAsText } from '../../src/util/messageBodyParser';
 
 describe('messageBodyParser', () => {
     describe('messageBodyAsText', () => {
@@ -66,7 +66,7 @@ describe('messageBodyParser', () => {
         });
 
         it('should throw TypeError for a Buffer with invalid UTF-8 bytes', () => {
-            const message = { body: Buffer.from([0x80, 0x81, 0xFF]) };
+            const message = { body: Buffer.from([0x80, 0x81, 0xff]) };
             expect(() => messageBodyAsText(message)).to.throw(TypeError);
         });
     });

--- a/azure-functions-nodejs-extensions-servicebus/webpack.config.js
+++ b/azure-functions-nodejs-extensions-servicebus/webpack.config.js
@@ -56,6 +56,20 @@ module.exports = (_env, argv) => {
     const esmConfig = {
         ...commonConfig,
         experiments: { outputModule: true },
+        externalsType: 'node-commonjs',
+        module: {
+            ...commonConfig.module,
+            rules: [
+                {
+                    test: /\.tsx?$/,
+                    loader: 'ts-loader',
+                    options: {
+                        transpileOnly: true,
+                        compilerOptions: { module: 'esnext' },
+                    },
+                },
+            ],
+        },
         output: {
             path: `${__dirname}/dist/`,
             filename: isDevMode


### PR DESCRIPTION
All changes relate to `@azure/functions-extensions-servicebus`

* Fixes the Webpack + TypeScript configuration for ESM artifacts (doesn't touch commonjs output).
* Removes mimimist as a production dependency
* Bumps package's patch version