### PR TITLE
Build: onboard npm restores to Central Feed Service

### DIFF
--- a/azure-functions-nodejs-extensions-base/.npmrc
+++ b/azure-functions-nodejs-extensions-base/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-functions-nodejs-extensions-blob/.npmrc
+++ b/azure-functions-nodejs-extensions-blob/.npmrc
@@ -1,0 +1,4 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@nodable:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-functions-nodejs-extensions-connectors/.npmrc
+++ b/azure-functions-nodejs-extensions-connectors/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/azure-functions-nodejs-extensions-servicebus/.npmrc
+++ b/azure-functions-nodejs-extensions-servicebus/.npmrc
@@ -1,0 +1,8 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@grpc:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-sdsl:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@nodable:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@protobufjs:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -25,16 +25,28 @@ jobs:
           inputs:
               versionSpec: 22.x
           displayName: 'Install Node.js'
+        - task: CopyFiles@2
+          displayName: 'Stage clean npm configuration'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
+            contents: .npmrc
+            targetFolder: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)'
+            cleanTargetFolder: true
+        - task: npmAuthenticate@0
+          displayName: 'Authenticate source npm'
+          inputs:
+            workingFile: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)/.npmrc'
         - bash: |
-            cd $(EXTENSION_DIRECTORY)
-            npm ci 
+            npm ci
+          displayName: 'npm ci'
+          workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
         - bash: | 
-            cd $(EXTENSION_DIRECTORY)
             npm run build
             npm run minify
             npm prune --production
             npm pack
           displayName: 'npm run build'
+          workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
         - task: CopyFiles@2
           displayName: 'Copy files to staging'
           inputs:
@@ -47,13 +59,22 @@ jobs:
               package.json
               README.md
             targetFolder: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)'
-            cleanTargetFolder: true
-        - bash: | 
-            npm prune --production
+            cleanTargetFolder: false
+        - task: npmAuthenticate@0
+          displayName: 'Authenticate staged npm'
+          inputs:
+            workingFile: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)/.npmrc'
+        - bash: |
+            npm prune --production --legacy-peer-deps
           displayName: 'npm prune --production' # so that only production dependencies are included in SBOM
-        - bash: | 
+          workingDirectory: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)'
+        - bash: |
             npm pack
           displayName: 'npm pack'
+          workingDirectory: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)'
+        - bash: rm -f .npmrc
+          displayName: 'Remove staged npm configuration'
+          condition: always()
           workingDirectory: '$(Build.ArtifactStagingDirectory)/dropInput/$(EXTENSION_DIRECTORY)'
         - script: mkdir $(EXTENSION_DIRECTORY) && mv dropInput/$(EXTENSION_DIRECTORY)/*.tgz $(EXTENSION_DIRECTORY)
           displayName: 'Move package to dropOutput'

--- a/eng/templates/jobs/minimal-build.yml
+++ b/eng/templates/jobs/minimal-build.yml
@@ -19,13 +19,18 @@ jobs:
           inputs:
               versionSpec: 22.x
           displayName: 'Install Node.js'
+        - task: npmAuthenticate@0
+          displayName: 'Authenticate npm'
+          inputs:
+            workingFile: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)/.npmrc'
         - bash: |
-            cd $(EXTENSION_DIRECTORY)
-            npm ci 
+            npm ci
+          displayName: 'npm ci'
+          workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
         - bash: | 
-            cd $(EXTENSION_DIRECTORY)
             npm run build
             npm run minify
             npm prune --production
             npm pack
           displayName: 'npm run build'
+          workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'

--- a/eng/templates/official/jobs/tests.yml
+++ b/eng/templates/official/jobs/tests.yml
@@ -56,29 +56,30 @@ jobs:
       - task: NodeTool@0
         inputs:
           versionSpec: $(NODE_VERSION)
+      - task: npmAuthenticate@0
+        displayName: 'Authenticate npm'
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)/.npmrc'
       - bash: |
-          cd $(EXTENSION_DIRECTORY)
-        displayName: 'Install Node.js'
-      - bash: |
-          cd $(EXTENSION_DIRECTORY)
           npm ci
         displayName: 'npm ci'
+        workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
       - bash: |
-          cd $(EXTENSION_DIRECTORY)
           npm run build
         displayName: 'npm run build'
+        workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
       - bash: |
-          cd $(EXTENSION_DIRECTORY)
           npm run lint
         displayName: 'npm run lint'
+        workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
       - bash: |
-          cd $(EXTENSION_DIRECTORY)
           npm run updateVersion -- --validate
         displayName: 'validate version'
+        workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
       - bash: |
-          cd $(EXTENSION_DIRECTORY)
           npm test
         displayName: 'Run unit tests'
+        workingDirectory: '$(Build.SourcesDirectory)/$(EXTENSION_DIRECTORY)'
       - task: PublishTestResults@2
         displayName: 'Publish Unit Test Results'
         inputs:


### PR DESCRIPTION
## Summary
- route all four repository development/build npm roots through the Functions `public/upstream-public` CFS feed
- explicitly map every scope in each resolved production dependency graph: Base (none), Blob (`@azure`, `@nodable`, `@typespec`), Connectors (`@azure`, `@typespec`), and Service Bus (`@azure`, `@grpc`, `@js-sdsl`, `@nodable`, `@protobufjs`, `@types`, `@typespec`)
- authenticate every independently executable Azure Pipelines npm path with `npmAuthenticate@0` and structured `workingFile`/`workingDirectory` boundaries
- stage a clean canonical `.npmrc` before source authentication, authenticate detached packaging separately, and remove the staged config after packing
- preserve customer-facing samples, lockfile URLs, and shipped package contents unchanged

## Audit results
- no npm workspaces, global npm installs, sudo npm paths, or additional repository scripts/test fixtures perform package restores
- no NuGet or Python restore/install surface exists, so no NuGet/PipAuthenticate/uv configuration was added
- no `always-auth`, `replace-registry-host`, credential, direct-public registry, or lockfile rewrite was introduced
- official artifacts contain only the generated `.tgz`; `.npmrc`, credentials, lockfiles, and `node_modules` are excluded from pack manifests and tar contents

## Validation
- isolated cold-cache CFS restores with temporary Azure DevOps authentication and no direct npmjs/yarn/npmmirror access
- Base: build, lint, 10 tests, minify, package manifest, and detached artifact
- Blob: 61 tests, lint, build/minify under a temporary compatible lint fixture, package manifest, and detached artifact
- Connectors: build, lint, 33 tests, and package manifest in a detached fixture that faithfully supplies its existing sibling `azure-functions-4.15.1-preview.tgz`
- Service Bus: build, lint, 248 tests, minify, package manifest, and detached artifact
- path-with-spaces coverage for authenticated config, cache, copied-tree, and artifact paths
- all changed Azure Pipelines YAML parsed successfully; `git diff --check` passed

## Existing main-branch caveats
- Blob currently declares ESLint 10 with `@typescript-eslint` 5 / `eslint-webpack-plugin` 3, so plain `npm ci` and build reject that pre-existing toolchain combination; validation used temporary compatibility packages without changing manifests or lockfiles
- Connectors' checked-in lockfile references a sibling `../../azure-functions-nodejs-library/azure-functions-4.15.1-preview.tgz`; validation generated that expected tarball through CFS in an isolated copied tree